### PR TITLE
Add configuration-based links system for conference pages

### DIFF
--- a/_conferences/aire25.md
+++ b/_conferences/aire25.md
@@ -11,6 +11,19 @@ authors:
   - tobias_hey
 approaches:
   - LiSSA
+links:
+  - name: Paper (KITopen)
+    url: https://publikationen.bibliothek.kit.edu/1000183058
+  - name: Paper (IEEE Xplore)
+    url: https://ieeexplore.ieee.org/document/11190238
+  - name: Replication Package (Zenodo)
+    url: https://doi.org/10.5281/zenodo.15837231
+  - name: Replication Package (GitHub)
+    url: https://github.com/ardoco/Replication-Package-AIRE25_Beyond-Retrieval-Using-LLM-Ensembles-for-Candidate-Filtering-in-Req-TLR
+  - name: Slides (PPTX)
+    url: /assets/pdf/presentation_aire25.pptx
+  - name: Slides (PDF)
+    url: /assets/pdf/presentation_aire25.pdf
 ---
 
 Published at the [33rd International Requirements Engineering Conference Workshops (REW)](https://aire-ws.github.io/aire25/).
@@ -37,9 +50,3 @@ While our LLM-based ensemble approach achieves comparable F2-scores to IR method
 **[Conclusion]**
 This work provides insights into the capabilities of small LLMs as a filter in inter-requirements TLR.
 Moreover, it provides insights into the performance of traditional IR techniques for TLR and their dependency on hyperparameters.
-
-## Links
-
-- Paper on [KITopen](https://publikationen.bibliothek.kit.edu/1000183058) and [IEEE Xplore](https://ieeexplore.ieee.org/document/11190238)
-- Replication Package on [Zenodo](https://doi.org/10.5281/zenodo.15837231) and the corresponding [GitHub repository](https://github.com/ardoco/Replication-Package-AIRE25_Beyond-Retrieval-Using-LLM-Ensembles-for-Candidate-Filtering-in-Req-TLR)
-- Slides as [pptx](/assets/pdf/presentation_aire25.pptx) or [pdf](/assets/pdf/presentation_aire25.pdf)

--- a/_conferences/ecsa21.md
+++ b/_conferences/ecsa21.md
@@ -13,6 +13,15 @@ authors:
   - anne_koziolek
 approaches:
   - SWATTR
+links:
+  - name: Paper (Springer Link)
+    url: https://doi.org/10.1007/978-3-030-86044-8_7
+  - name: Paper (KITopen)
+    url: https://doi.org/10.5445/IR/1000138399
+  - name: Replication Package (Zenodo)
+    url: https://doi.org/10.5281/zenodo.4730621
+  - name: Replication Package (GitHub)
+    url: https://github.com/ardoco/SWATTR
 ---
 
 Published at the [15th European Conference on Software Architecture (ECSA 2021), September 13-17 2021](https://conf.researchr.org/home/ecsa-2021)
@@ -32,9 +41,3 @@ In each stage, multiple agents can be used to capture necessary information to a
 We evaluate the performance of our approach with three case studies and compare our results to baseline approaches.
 The results for our approach are good to excellent with a weighted average F1-Score of 0.72 over all case studies.
 Moreover, our approach outperforms the baseline approaches on non-weighted average by at least 0.24 (weighted 0.31).
-
-## Links
-
-- Paper on [Springer Link](https://doi.org/10.1007/978-3-030-86044-8_7) and on [KITopen](https://doi.org/10.5445/IR/1000138399)
-- Replication Package on [Zenodo](https://doi.org/10.5281/zenodo.4730621) and the corresponding [GitHub repository](https://github.com/ardoco/SWATTR)
-<!-- - [Slides](/assets/pdf/presentation_21_ecsa_TLR.pdf) -->

--- a/_conferences/fg-arch24.md
+++ b/_conferences/fg-arch24.md
@@ -6,19 +6,16 @@ description:
 authors:
   - jan_keim
   - tobias_hey
-links:
-  - name: Slides
-    url: /assets/pdf/presentation_fgarch24_keim.pdf
-  - name: Jay Alammar's ML Visualizations Blog
-    url: https://jalammar.github.io/
-  - name: "Related: Taxonomy for Design Decisions (ECSA-C 2022)"
-    url: https://doi.org/10.1007/978-3-031-36889-9_29
-  - name: "Related: Does BERT Understand Code? (ECSA 2020)"
-    url: https://doi.org/10.1007/978-3-030-58923-3_15
-  - name: "Related: Recovering Trace Links (ICSE 2024)"
-    url: https://doi.org/10.1145/3597503.3639130
 ---
 
 ![FGARCH24 Titleslide](/assets/img/approaches/fgarch24-titleslide.png){:width="100%" style="background-color: white; border-radius: 8px; padding: 10px; display: block; margin: 0 auto;"}
 
 Vortrag bei der Jahrestagung der GI-Fachgruppe "Architekturen" am 24. und 25. Oktober 2024 in Paderborn.
+
+## Links und relevante Publikationen
+
+- [Folien der Präsentation](/assets/pdf/presentation_fgarch24_keim.pdf)
+- [Blog von Jay Alammar mit Visualisierungen von ML Konzepten](https://jalammar.github.io/)
+- Klassifizierung von Entwurfsentscheidungen: [Keim et al., _A Taxonomy for Design Decisions in Software Architecture Documentation_](https://doi.org/10.1007/978-3-031-36889-9_29), ECSA-C 2022. ([Open Access Postprint @ KITOpen](https://doi.org/10.5445/IR/1000160794/post))
+- Identifikation von Architekturtaktiken: [Keim et al., _Does BERT Understand Code? : An Exploratory Study on the Detection of Architectural Tactics in Code_](https://doi.org/10.1007/978-3-030-58923-3_15), ECSA 2020. ([Open Access Postprint @ KITOpen](https://doi.org/10.5445/IR/1000124838))
+- Traceability Link Recovery: [Keim et al., _Recovering Trace Links Between Software Documentation And Code_](https://doi.org/10.1145/3597503.3639130), ICSE 2024. ([Open Access @ KITOpen](https://doi.org/10.5445/IR/1000165692/pub))

--- a/_conferences/fg-arch24.md
+++ b/_conferences/fg-arch24.md
@@ -6,16 +6,19 @@ description:
 authors:
   - jan_keim
   - tobias_hey
+links:
+  - name: Slides
+    url: /assets/pdf/presentation_fgarch24_keim.pdf
+  - name: Jay Alammar's ML Visualizations Blog
+    url: https://jalammar.github.io/
+  - name: "Related: Taxonomy for Design Decisions (ECSA-C 2022)"
+    url: https://doi.org/10.1007/978-3-031-36889-9_29
+  - name: "Related: Does BERT Understand Code? (ECSA 2020)"
+    url: https://doi.org/10.1007/978-3-030-58923-3_15
+  - name: "Related: Recovering Trace Links (ICSE 2024)"
+    url: https://doi.org/10.1145/3597503.3639130
 ---
 
 ![FGARCH24 Titleslide](/assets/img/approaches/fgarch24-titleslide.png){:width="100%" style="background-color: white; border-radius: 8px; padding: 10px; display: block; margin: 0 auto;"}
 
 Vortrag bei der Jahrestagung der GI-Fachgruppe "Architekturen" am 24. und 25. Oktober 2024 in Paderborn.
-
-## Links und relevante Publikationen
-
-- [Folien der Präsentation](/assets/pdf/presentation_fgarch24_keim.pdf)
-- [Blog von Jay Alammar mit Visualisierungen von ML Konzepten](https://jalammar.github.io/)
-- Klassifizierung von Entwurfsentscheidungen: [Keim et al., _A Taxonomy for Design Decisions in Software Architecture Documentation_](https://doi.org/10.1007/978-3-031-36889-9_29), ECSA-C 2022. ([Open Access Postprint @ KITOpen](https://doi.org/10.5445/IR/1000160794/post))
-- Identifikation von Architekturtaktiken: [Keim et al., _Does BERT Understand Code? : An Exploratory Study on the Detection of Architectural Tactics in Code_](https://doi.org/10.1007/978-3-030-58923-3_15), ECSA 2020. ([Open Access Postprint @ KITOpen](https://doi.org/10.5445/IR/1000124838))
-- Traceability Link Recovery: [Keim et al., _Recovering Trace Links Between Software Documentation And Code_](https://doi.org/10.1145/3597503.3639130), ICSE 2024. ([Open Access @ KITOpen](https://doi.org/10.5445/IR/1000165692/pub))

--- a/_conferences/icsa23.md
+++ b/_conferences/icsa23.md
@@ -12,6 +12,19 @@ authors:
 approaches:
   - SWATTR
   - "Inconsistency Detection"
+links:
+  - name: Paper (IEEE Xplore)
+    url: https://doi.org/10.1109/ICSA56044.2023.00021
+  - name: Paper (KITopen)
+    url: https://doi.org/10.5445/IR/1000158208
+  - name: Replication Package (Zenodo)
+    url: https://doi.org/10.5281/zenodo.7555194
+  - name: Replication Package (GitHub)
+    url: https://github.com/ardoco/DetectingInconsistenciesInSoftwareArchitectureDocumentationUsingTraceabilityLinkRecovery
+  - name: Slides ICSA23 (PDF)
+    url: /assets/pdf/presentation_23_ICSA_InconsistencyDetection.pdf
+  - name: Slides SE24 (PDF)
+    url: /assets/pdf/presentation_24_SE_InconsistencyDetection.pdf
 ---
 
 Published at the [20th IEEE International Conference on Software Architecture (ICSA 2023), March 13-17 2023](https://icsa-conferences.org/2023/).
@@ -23,10 +36,3 @@ Additional presentation at the [Software Engineering 2024 (SE24)](https://se2024
 ## Abstract
 
 Documenting software architecture is important for a system’s success. Software architecture documentation (SAD) makes information about the system available and eases comprehensibility. There are different forms of SADs like natural language texts and formal models with different benefits and different purposes. However, there can be inconsistent information in different SADs for the same system. Inconsistent documentation then can cause flaws in development and maintenance. To tackle this, we present an approach for inconsistency detection in natural language SAD and formal architecture models. We make use of traceability link recovery (TLR) and extend an existing approach. We utilize the results from TLR to detect unmentioned (i.e., model elements without natural language documentation) and missing model elements (i.e., described but not modeled elements). In our evaluation, we measure how the adaptations on TLR affected its performance. Moreover, we evaluate the inconsistency detection. We use a benchmark with multiple open source projects and compare the results with existing and baseline approaches. For TLR, we achieve an excellent F1-score of 0.81, significantly outperforming the other approaches by at least 0.24. Our approach also achieves excellent results (accuracy: 0.93) for detecting unmentioned model elements and good results for detecting missing model elements (accuracy: 0.75). These results also significantly outperform competing baselines. Although we see room for improvements, the results show that detecting inconsistencies using TLR is promising.
-
-## Links
-
-- Paper on [IEEE Xplore](https://doi.org/10.1109/ICSA56044.2023.00021) and on [KITopen](https://doi.org/10.5445/IR/1000158208)
-- Replication Package on [Zenodo](https://doi.org/10.5281/zenodo.7555194) and the corresponding [GitHub repository](https://github.com/ardoco/DetectingInconsistenciesInSoftwareArchitectureDocumentationUsingTraceabilityLinkRecovery)
-- [Slides (ICSA23)](/assets/pdf/presentation_23_ICSA_InconsistencyDetection.pdf)
-- [Slides (SE24)](/assets/pdf/presentation_24_SE_InconsistencyDetection.pdf)

--- a/_conferences/icsa25.md
+++ b/_conferences/icsa25.md
@@ -13,6 +13,19 @@ authors:
 approaches:
   - ExArch
   - TransArC
+links:
+  - name: Paper (IEEE Xplore)
+    url: https://doi.org/10.1109/ICSA65012.2025.00011
+  - name: Paper (KITopen)
+    url: https://publikationen.bibliothek.kit.edu/1000179830
+  - name: Replication Package (Zenodo)
+    url: https://doi.org/10.5281/zenodo.14506935
+  - name: Replication Package (GitHub)
+    url: https://github.com/ardoco/ReplicationPackage-EnablingArchitectureTraceabilitybyLLM-basedArchitectureComponentNameExtraction
+  - name: Slides (PPTX)
+    url: /assets/pdf/presentation_icsa25.pptx
+  - name: Slides (PDF)
+    url: /assets/pdf/presentation_icsa25.pdf
 ---
 
 Published at the [22nd IEEE International Conference on Software Architecture (ICSA 2025), March 31 - April 04 2025](https://conf.researchr.org/home/icsa-2025/).
@@ -33,9 +46,3 @@ TransArC is the currently best-performing approach for TLR between SAD and sourc
 Our evaluation shows that our approach performs comparable to TransArC (weighted average F1 with GPT-4o: 0.86 vs. TransArC's 0.87), while only needing the SAD and source code.
 Moreover, our approach significantly outperforms the best baseline that does not need SAMs (weighted average F1 with GPT-4o: 0.86 vs. ArDoCode's 0.62).
 In summary, our approach shows that LLMs can be used to make TLR between SAD and source code more applicable by extracting component names and omitting the need for manually created SAMs.
-
-## Links
-
-- Paper on [IEEE Xplore](https://doi.org/10.1109/ICSA65012.2025.00011) or [KITopen](https://publikationen.bibliothek.kit.edu/1000179830)
-- Replication Package on [Zenodo](https://doi.org/10.5281/zenodo.14506935) and the corresponding [GitHub repository](https://github.com/ardoco/ReplicationPackage-EnablingArchitectureTraceabilitybyLLM-basedArchitectureComponentNameExtraction)
-- Slides as [pptx](/assets/pdf/presentation_icsa25.pptx) or [pdf](/assets/pdf/presentation_icsa25.pdf)

--- a/_conferences/icse24.md
+++ b/_conferences/icse24.md
@@ -16,6 +16,21 @@ approaches:
   - ArCoTL
   - SWATTR
   - ArDoCode
+links:
+  - name: Paper (ACM Open Access)
+    url: https://doi.org/10.1145/3597503.3639130
+  - name: Paper (KITopen)
+    url: https://doi.org/10.5445/IR/1000165692
+  - name: Replication Package (Zenodo)
+    url: https://doi.org/10.5281/zenodo.10411853
+  - name: Replication Package (GitHub)
+    url: https://github.com/ardoco/Replication-Package-ICSE24_Recovering-Trace-Links-Between-Software-Documentation-And-Code
+  - name: Slides ICSE24 (PPTX)
+    url: /assets/pdf/presentation_icse24.pptx
+  - name: Slides ICSE24 (PDF)
+    url: /assets/pdf/presentation_icse24.pdf
+  - name: Slides SE25 (PDF)
+    url: /assets/pdf/presentation_25_SE_TransArC.pdf
 ---
 
 Published at the [46th International Conference on Software Engineering (ICSE 2024), April 14-20 2024](https://conf.researchr.org/home/icse-2024).
@@ -43,10 +58,3 @@ The model-to-code TLR approach achieves an average F1-score of 0.98, while the d
 _Conclusion_
 Combining two specialized approaches with an intermediate artifact shows promise for bridging the semantic gap.
 In future research, we will explore further possibilities for such transitive approaches.
-
-## Links
-
-- Paper (Open Access) on [ACM](https://doi.org/10.1145/3597503.3639130) or [KITopen](https://doi.org/10.5445/IR/1000165692)
-- Replication Package on [Zenodo](https://doi.org/10.5281/zenodo.10411853) and the corresponding [GitHub repository](https://github.com/ardoco/Replication-Package-ICSE24_Recovering-Trace-Links-Between-Software-Documentation-And-Code)
-- Slides as [pptx](/assets/pdf/presentation_icse24.pptx) or [pdf](/assets/pdf/presentation_icse24.pdf)
-- [Slides (SE25)](/assets/pdf/presentation_25_SE_TransArC.pdf)

--- a/_conferences/icse25.md
+++ b/_conferences/icse25.md
@@ -14,6 +14,19 @@ authors:
   - anne_koziolek
 approaches:
   - LiSSA
+links:
+  - name: Paper (IEEE Xplore)
+    url: https://doi.org/10.1109/ICSE55347.2025.00186
+  - name: Paper (KITopen)
+    url: https://publikationen.bibliothek.kit.edu/1000179816
+  - name: Replication Package (Zenodo)
+    url: https://doi.org/10.5281/zenodo.14714706
+  - name: Replication Package (GitHub)
+    url: https://github.com/ardoco/ReplicationPackage-ICSE25_LiSSA-Toward-Generic-Traceability-Link-Recovery-through-RAG/tree/main
+  - name: Slides (PPTX)
+    url: /assets/pdf/presentation_icse25.pptx
+  - name: Slides (PDF)
+    url: /assets/pdf/presentation_icse25.pdf
 ---
 
 Published at the [47th IEEE/ACM International Conference on Software Engineering (ICSE 2025), April 27 - May 03 2025](https://conf.researchr.org/home/icse-2025/).
@@ -34,9 +47,3 @@ We empirically evaluate LiSSA on three different TLR tasks, requirements to code
 
 Our results show that the RAG-based approach can significantly outperform the state-of-the-art on the code-related tasks.
 However, further research is required to improve the performance of RAG-based approaches to be applicable in practice.
-
-## Links
-
-- Paper on [IEEE Xplore](https://doi.org/10.1109/ICSE55347.2025.00186) or [KITopen](https://publikationen.bibliothek.kit.edu/1000179816)
-- Replication Package on [Zenodo](https://doi.org/10.5281/zenodo.14714706) and the corresponding [GitHub repository](https://github.com/ardoco/ReplicationPackage-ICSE25_LiSSA-Toward-Generic-Traceability-Link-Recovery-through-RAG/tree/main)
-- Slides as [pptx](/assets/pdf/presentation_icse25.pptx) or [pdf](/assets/pdf/presentation_icse25.pdf)

--- a/_conferences/refsq25.md
+++ b/_conferences/refsq25.md
@@ -11,6 +11,15 @@ authors:
   - anne_koziolek
 approaches:
   - LiSSA
+links:
+  - name: Paper (KITopen)
+    url: https://publikationen.bibliothek.kit.edu/1000179817
+  - name: Paper (Springer Nature)
+    url: https://doi.org/10.1007/978-3-031-88531-0_27
+  - name: Replication Package (Zenodo)
+    url: https://doi.org/10.5281/zenodo.14779457
+  - name: Replication Package (GitHub)
+    url: https://github.com/ardoco/ReplicationPackage-REFSQ25_Requirements-TLR-via-RAG
 ---
 
 Published at the [31st International Working Conference on Requirements Engineering: Foundation for Software Quality](https://2025.refsq.org/).
@@ -33,8 +42,3 @@ We propose to address this limitation by leveraging large language models (LLMs)
 In an empirical evaluation on six benchmark datasets, we show that chain-of-thought prompting can be beneficial, open-source models perform comparably to proprietary ones, and that the approach can outperform state-of-the-art and baseline approaches.
 
 **[Contribution]** This work presents an approach for inter-requirements traceability link recovery using RAG and provides the first empirical evidence of its performance.
-
-## Links
-
-- Paper on [KITopen](https://publikationen.bibliothek.kit.edu/1000179817) or [Springer Nature](https://doi.org/10.1007/978-3-031-88531-0_27)
-- Replication Package on [Zenodo](https://doi.org/10.5281/zenodo.14779457) and the corresponding [GitHub repository](https://github.com/ardoco/ReplicationPackage-REFSQ25_Requirements-TLR-via-RAG)

--- a/_layouts/publication.liquid
+++ b/_layouts/publication.liquid
@@ -56,6 +56,42 @@ layout: default
       </div>
     {% endif %}
     {{ content }}
+    
+    {% if page.links %}
+      <h2>Links</h2>
+      
+      {% comment %} Group links by type (extracted from name before parenthesis) {% endcomment %}
+      {% assign grouped_links = page.links | group_by_exp: "link", "link.name | split: ' (' | first" %}
+      
+      <ul>
+      {% for group in grouped_links %}
+        {% assign group_name = group.name %}
+        {% assign links = group.items %}
+        
+        {% if links.size > 1 %}
+          {% comment %} Multiple links of same type {% endcomment %}
+          {% if group_name == "Slides" %}
+            {% comment %} Generic slides without conference prefix {% endcomment %}
+            <li>{{ group_name }} as {% for link in links %}{% assign link_label = link.name | split: '(' | last | split: ')' | first %}<a href="{{ link.url }}">{{ link_label }}</a>{% unless forloop.last %} or {% endunless %}{% endfor %}</li>
+          {% elsif group_name contains "Slides" %}
+            {% comment %} Conference-specific slides like "Slides ICSE24" {% endcomment %}
+            <li>{{ group_name }} as {% for link in links %}{% assign link_label = link.name | split: '(' | last | split: ')' | first %}<a href="{{ link.url }}">{{ link_label }}</a>{% unless forloop.last %} or {% endunless %}{% endfor %}</li>
+          {% else %}
+            <li>{{ group_name }} on {% for link in links %}{% assign link_label = link.name | split: '(' | last | split: ')' | first %}<a href="{{ link.url }}">{{ link_label }}</a>{% unless forloop.last %} and {% endunless %}{% endfor %}</li>
+          {% endif %}
+        {% else %}
+          {% comment %} Single link {% endcomment %}
+          {% assign link = links[0] %}
+          {% if link.name contains "Slides" %}
+            {% comment %} For single slide links, just display the full name as-is {% endcomment %}
+            <li><a href="{{ link.url }}">{{ link.name }}</a></li>
+          {% else %}
+            <li><a href="{{ link.url }}">{{ link.name }}</a></li>
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+      </ul>
+    {% endif %}
   </article>
 
   {% if page.related_publications %}

--- a/_layouts/publication.liquid
+++ b/_layouts/publication.liquid
@@ -103,16 +103,9 @@ layout: default
           {% else %}
             {% comment %} Single link {% endcomment %}
             {% assign link = links[0] %}
-            {% if link.name contains 'Slides' %}
-              {% comment %} For single slide links, just display the full name as-is {% endcomment %}
-              <li>
-                <a href="{{ link.url }}">{{ link.name }}</a>
-              </li>
-            {% else %}
-              <li>
-                <a href="{{ link.url }}">{{ link.name }}</a>
-              </li>
-            {% endif %}
+            <li>
+              <a href="{{ link.url }}">{{ link.name }}</a>
+            </li>
           {% endif %}
         {% endfor %}
       </ul>

--- a/_layouts/publication.liquid
+++ b/_layouts/publication.liquid
@@ -56,40 +56,65 @@ layout: default
       </div>
     {% endif %}
     {{ content }}
-    
+
     {% if page.links %}
       <h2>Links</h2>
-      
+
       {% comment %} Group links by type (extracted from name before parenthesis) {% endcomment %}
-      {% assign grouped_links = page.links | group_by_exp: "link", "link.name | split: ' (' | first" %}
-      
+      {% assign grouped_links = page.links | group_by_exp: 'link', "link.name | split: ' (' | first" %}
+
       <ul>
-      {% for group in grouped_links %}
-        {% assign group_name = group.name %}
-        {% assign links = group.items %}
-        
-        {% if links.size > 1 %}
-          {% comment %} Multiple links of same type {% endcomment %}
-          {% if group_name == "Slides" %}
-            {% comment %} Generic slides without conference prefix {% endcomment %}
-            <li>{{ group_name }} as {% for link in links %}{% assign link_label = link.name | split: '(' | last | split: ')' | first %}<a href="{{ link.url }}">{{ link_label }}</a>{% unless forloop.last %} or {% endunless %}{% endfor %}</li>
-          {% elsif group_name contains "Slides" %}
-            {% comment %} Conference-specific slides like "Slides ICSE24" {% endcomment %}
-            <li>{{ group_name }} as {% for link in links %}{% assign link_label = link.name | split: '(' | last | split: ')' | first %}<a href="{{ link.url }}">{{ link_label }}</a>{% unless forloop.last %} or {% endunless %}{% endfor %}</li>
+        {% for group in grouped_links %}
+          {% assign group_name = group.name %}
+          {% assign links = group.items %}
+
+          {% if links.size > 1 %}
+            {% comment %} Multiple links of same type {% endcomment %}
+            {% if group_name == 'Slides' %}
+              {% comment %} Generic slides without conference prefix {% endcomment %}
+              <li>
+                {{ group_name }} as
+                {% for link in links -%}
+                  {%- assign link_label = link.name | split: '(' | last | split: ')' | first -%}
+                  <a href="{{ link.url }}">{{ link_label }}</a>
+                  {%- unless forloop.last %} or {% endunless -%}
+                {%- endfor %}
+              </li>
+            {% elsif group_name contains 'Slides' %}
+              {% comment %} Conference-specific slides like "Slides ICSE24" {% endcomment %}
+              <li>
+                {{ group_name }} as
+                {% for link in links -%}
+                  {%- assign link_label = link.name | split: '(' | last | split: ')' | first -%}
+                  <a href="{{ link.url }}">{{ link_label }}</a>
+                  {%- unless forloop.last %} or {% endunless -%}
+                {%- endfor %}
+              </li>
+            {% else %}
+              <li>
+                {{ group_name }} on
+                {% for link in links -%}
+                  {%- assign link_label = link.name | split: '(' | last | split: ')' | first -%}
+                  <a href="{{ link.url }}">{{ link_label }}</a>
+                  {%- unless forloop.last %} and {% endunless -%}
+                {%- endfor %}
+              </li>
+            {% endif %}
           {% else %}
-            <li>{{ group_name }} on {% for link in links %}{% assign link_label = link.name | split: '(' | last | split: ')' | first %}<a href="{{ link.url }}">{{ link_label }}</a>{% unless forloop.last %} and {% endunless %}{% endfor %}</li>
+            {% comment %} Single link {% endcomment %}
+            {% assign link = links[0] %}
+            {% if link.name contains 'Slides' %}
+              {% comment %} For single slide links, just display the full name as-is {% endcomment %}
+              <li>
+                <a href="{{ link.url }}">{{ link.name }}</a>
+              </li>
+            {% else %}
+              <li>
+                <a href="{{ link.url }}">{{ link.name }}</a>
+              </li>
+            {% endif %}
           {% endif %}
-        {% else %}
-          {% comment %} Single link {% endcomment %}
-          {% assign link = links[0] %}
-          {% if link.name contains "Slides" %}
-            {% comment %} For single slide links, just display the full name as-is {% endcomment %}
-            <li><a href="{{ link.url }}">{{ link.name }}</a></li>
-          {% else %}
-            <li><a href="{{ link.url }}">{{ link.name }}</a></li>
-          {% endif %}
-        {% endif %}
-      {% endfor %}
+        {% endfor %}
       </ul>
     {% endif %}
   </article>

--- a/_layouts/publication.liquid
+++ b/_layouts/publication.liquid
@@ -70,18 +70,7 @@ layout: default
 
           {% if links.size > 1 %}
             {% comment %} Multiple links of same type {% endcomment %}
-            {% if group_name == 'Slides' %}
-              {% comment %} Generic slides without conference prefix {% endcomment %}
-              <li>
-                {{ group_name }} as
-                {% for link in links -%}
-                  {%- assign link_label = link.name | split: '(' | last | split: ')' | first -%}
-                  <a href="{{ link.url }}">{{ link_label }}</a>
-                  {%- unless forloop.last %} or {% endunless -%}
-                {%- endfor %}
-              </li>
-            {% elsif group_name contains 'Slides' %}
-              {% comment %} Conference-specific slides like "Slides ICSE24" {% endcomment %}
+            {% if group_name contains 'Slides' %}
               <li>
                 {{ group_name }} as
                 {% for link in links -%}


### PR DESCRIPTION
## Summary
This PR adds a configuration-based links system for conference publication pages, making it easier to maintain and ensuring consistent presentation across all conference pages.

## Changes
- **Generic links structure**: Added a flexible `links` array to conference front matter supporting multiple link types with custom names
- **Updated 7 conference files**: Migrated hardcoded Links sections to YAML configuration (AIRE25, ICSE24, ICSE25, ECSA21, ICSA23, ICSA25, REFSQ25)
- **FG-Arch24 unchanged**: Kept original German formatting for this presentation page
- **Enhanced publication layout**: Modified `_layouts/publication.liquid` to automatically render links with smart formatting
- **Intelligent grouping**: Links are automatically grouped by type (e.g., "Paper on KITopen and IEEE Xplore")
- **Grammatically correct formatting**: Uses "as...or" for slides/presentations, "on...and" for papers and replication packages
- **Conference-specific presentations**: Properly handles multiple presentations at different conferences (e.g., Slides ICSE24, Slides SE25)

## Link Types Supported
The flexible configuration automatically handles various link types:
- **Paper**: Multiple sources grouped together (e.g., "Paper on KITopen and IEEE Xplore")
- **Replication Package**: Zenodo and GitHub repositories grouped together
- **Slides**: Multiple formats grouped by conference (e.g., "Slides ICSE24 as PPTX or PDF")
- **Presentation**: Conference-specific presentations listed separately when from different conferences

## Link Type Detection
The system automatically detects link types by parsing the link name:
- Links starting with "Paper (...)" are grouped as Papers
- Links starting with "Replication Package (...)" are grouped as Replication Packages
- Links starting with "Slides [Conference] (...)" are grouped by conference
- Other links are displayed individually

## Examples
**AIRE25**: 
- Paper on KITopen and IEEE Xplore
- Replication Package on Zenodo and GitHub
- Slides as PPTX or PDF

**ICSE24**: 
- Paper on ACM Open Access and KITopen
- Replication Package on Zenodo and GitHub
- Slides ICSE24 as PPTX or PDF
- Slides SE25 (PDF)

**FG-Arch24**: Kept original German "Links und relevante Publikationen" section (unchanged)

## Benefits
- Easy to add, modify, or remove links without touching markdown content
- Consistent presentation across conference pages
- Automatic formatting with proper grammar
- Supports any number of links with custom names
- Handles complex scenarios like multiple conference presentations
- All existing links verified and working correctly

## Verification
✅ 7 conference files migrated and verified
✅ 1 conference file (FG-Arch24) kept in original format
✅ All links migrated correctly
✅ No unintended hardcoded sections removed
✅ All URLs verified and working